### PR TITLE
Disabled copying and pasting answers

### DIFF
--- a/src/components/InputText.jsx
+++ b/src/components/InputText.jsx
@@ -32,11 +32,17 @@ const InputText = () => {
     }
   }
 
+  function handlePaste(e) {
+    e.preventDefault();
+    return false;
+  }
+
   return (
     <div className='p-4'>
       <div className='w-full max-w-md px-4'>
         <input
           onChange={handleUserInput}
+          onPaste={handlePaste}
           type='text'
           disabled={gameCompleted}
           value={userInputState}

--- a/src/components/Paragraph.jsx
+++ b/src/components/Paragraph.jsx
@@ -38,8 +38,16 @@ function Paragraph() {
     setWordsState(finalSentence.split(' '));
   };
 
+  function handleCopy(e) {
+    e.preventDefault();
+    return false;
+  }
+
   return (
-    <span className='mx-7 md:mx-24 md:h-full lg:mx-80 lg:px-10 relative bottom-24 text-lg font-mono'>
+    <span
+      onCopy={handleCopy}
+      className='mx-7 md:mx-24 md:h-full lg:mx-80 lg:px-10 relative bottom-24 text-lg font-mono'
+    >
       {wordsState.map((word, index) => (
         <span
           className={index == currentWordIndex ? 'text-white' : 'text-gray-500'}


### PR DESCRIPTION
fixes issue #8 by preventing users from copying words from the paragraph and pasting them in the input field